### PR TITLE
Fix: mutation locale des props dans le composant MenuItem

### DIFF
--- a/cafe-with-a-vue/cli-version/src/App.vue
+++ b/cafe-with-a-vue/cli-version/src/App.vue
@@ -2,22 +2,23 @@
 	<div id="app" class="app">
 		<h1>{{ restaurantName }}</h1>
 		<p class="description">
-			Bienvenue dans notre café {{ restaurantName }}! Nous sommes réputés pour
-			notre pain et nos merveilleuses pâtisseries. Faites vous plaisir dès le
-			matin ou avec un goûter réconfortant. Mais attention, vous verrez qu'il
-			est difficile de s'arrêter.
+			Bienvenue dans notre café {{ restaurantName }}! Nous sommes réputés pour notre
+			pain et nos merveilleuses pâtisseries. Faites vous plaisir dès le matin ou
+			avec un goûter réconfortant. Mais attention, vous verrez qu'il est difficile
+			de s'arrêter.
 		</p>
 
 		<section class="menu">
 			<h2>Menu</h2>
 			<MenuItem
-				v-for="item in simpleMenu"
+				v-for="(item, index) in simpleMenu"
 				:addToShoppingCart="addToShoppingCart"
 				:name="item.name"
 				:image="item.image"
 				:quantity="item.quantity"
 				:inStock="item.inStock"
 				:key="item.name"
+				:index="index"
 			/>
 		</section>
 
@@ -42,69 +43,75 @@
 </template>
 
 <script>
-import MenuItem from "./components/MenuItem"
+import MenuItem from './components/MenuItem';
 
 export default {
-	name: "App",
+	name: 'App',
 	components: {
-		MenuItem
+		MenuItem,
 	},
 	data() {
 		return {
-			address: "18 avenue du Beurre, Paris, France",
-			email: "hello@cafewithavue.bakery",
-			phone: "01 88 88 88 88",
-			restaurantName: "La belle vue",
-			shoppingCart: 0,
+			address: '18 avenue du Beurre, Paris, France',
+			email: 'hello@cafewithavue.bakery',
+			phone: '01 88 88 88 88',
+			restaurantName: 'La belle vue',
 			simpleMenu: [
 				{
-					name: "Croissant",
+					name: 'Croissant',
 					image: {
-						source: "/images/crossiant.jpg",
-						alt: "Un croissant"
+						source: '/images/crossiant.jpg',
+						alt: 'Un croissant',
 					},
 					inStock: true,
-					quantity: 1
+					quantity: 1,
 				},
 				{
-					name: "Baguette de pain",
+					name: 'Baguette de pain',
 					image: {
-						source: "/images/french-baguette.jpeg",
-						alt: "Quatre baguettes de pain"
+						source: '/images/french-baguette.jpeg',
+						alt: 'Quatre baguettes de pain',
 					},
 					inStock: true,
-					quantity: 1
+					quantity: 1,
 				},
 				{
-					name: "Éclair",
+					name: 'Éclair',
 					image: {
-						source: "/images/eclair.jpg",
-						alt: "Éclair au chocolat"
+						source: '/images/eclair.jpg',
+						alt: 'Éclair au chocolat',
 					},
 					inStock: false,
-					quantity: 1
-				}
-			]
-		}
+					quantity: 1,
+				},
+			],
+		};
 	},
 	computed: {
 		copyright() {
-			const currentYear = new Date().getFullYear()
+			const currentYear = new Date().getFullYear();
 
-			return `Copyright ${this.restaurantName} ${currentYear}`
-		}
+			return `Copyright ${this.restaurantName} ${currentYear}`;
+		},
+		shoppingCart() {
+			let total = 0;
+			this.simpleMenu.forEach(element => {
+				total += element.quantity;
+			});
+			return total;
+		},
 	},
 	methods: {
-		addToShoppingCart(amount) {
-			this.shoppingCart += amount
-		}
-	}
-}
+		addToShoppingCart(amount, index) {
+			return (this.simpleMenu[index].quantity = amount);
+		},
+	},
+};
 </script>
 
 <style lang="scss">
 #app {
-	font-family: "Avenir", Helvetica, Arial, sans-serif;
+	font-family: 'Avenir', Helvetica, Arial, sans-serif;
 	-webkit-font-smoothing: antialiased;
 	-moz-osx-font-smoothing: grayscale;
 	text-align: center;

--- a/cafe-with-a-vue/cli-version/src/components/MenuItem.vue
+++ b/cafe-with-a-vue/cli-version/src/components/MenuItem.vue
@@ -1,8 +1,13 @@
 <script>
 export default {
-	name: "MenuItem",
-	props: ["addToShoppingCart", "image", "inStock", "name", "quantity"]
-}
+	name: 'MenuItem',
+	props: ['addToShoppingCart', 'image', 'inStock', 'name', 'quantity', 'index'],
+	data() {
+		return {
+			newQuantity: 1,
+		};
+	},
+};
 </script>
 
 <template>
@@ -14,8 +19,12 @@ export default {
 			<p v-else>En rupture de stock</p>
 			<div>
 				<label for="add-item-quantity">Quantité : {{ quantity }}</label>
-				<input v-model.number="quantity" id="add-item-quantity" type="number" />
-				<button @click="addToShoppingCart(quantity)">
+				<input
+					v-model.number="newQuantity"
+					id="add-item-quantity"
+					type="number"
+				/>
+				<button @click="addToShoppingCart(newQuantity, index)">
 					Ajouter au panier
 				</button>
 			</div>


### PR DESCRIPTION
Une fois le serveur de développement lancé sur la branche "P2C2-Solution", le message suivant apparaît dans la console du navigateur :

![error_prop_mutation](https://user-images.githubusercontent.com/62557549/106805669-48901980-6667-11eb-815c-4dc91aaed078.png)


Cet avertissement fait référence au paragraphe suivant de la documentation vuejs :

![doc_prop_mutation](https://user-images.githubusercontent.com/62557549/106806207-f13e7900-6667-11eb-935c-0d314b728afe.png)
https://vuejs.org/v2/guide/migration.html#Prop-Mutation-deprecated



**Proposition de fix**

1 - Passer l'index, récupéré depuis la directive v-for, en props au composant MenuItem

App.vue
![app_loop](https://user-images.githubusercontent.com/62557549/106808327-89d5f880-666a-11eb-8d4a-74c70a8b5740.png)


2 - Ajouter l'index aux props dans le composant MenuItem, ainsi qu'un data store avec une propriété 'newQuantity'

MenuItem.vue
![menuItem_script](https://user-images.githubusercontent.com/62557549/106808716-08cb3100-666b-11eb-8022-c8b8f4a2d8f8.png)


3 - Lier la directive v-model à cette propriété 'newQuantity' plutôt qu'à la prop 'quantity', et passer 'newQuantity' et l'index en paramètres à la méthode 'addToShoppingCart' pour l'event 'click'

MenuItem.vue
![menuItem_template](https://user-images.githubusercontent.com/62557549/106809090-8c851d80-666b-11eb-831c-df55eb5fa6ff.png)


4 - Modifier la méthode 'addToShoppingCart' dans le composant App pour qu'elle modifie la propriété 'quantity' de l'item correspondant à l'index passé. Remplacer la propriété 'shoppingCart' par une propriété calculée

App.vue
![app_computed_methods](https://user-images.githubusercontent.com/62557549/106809609-2d73d880-666c-11eb-83a6-ffac6f6d37cc.png)

